### PR TITLE
Deployment improvements

### DIFF
--- a/.github/workflows/build-push-rclient.yml
+++ b/.github/workflows/build-push-rclient.yml
@@ -24,14 +24,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Build
         uses: docker/build-push-action@v5
         with:
@@ -39,9 +31,9 @@ jobs:
           file: ${{ env.DOCKERFILE }}
           load: true
           tags: ${{ env.CONTAINER_NAME }}:testing
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       # - name: Test
       #   run: |
       #     expected=\

--- a/.github/workflows/build-push-shinyapp.yml
+++ b/.github/workflows/build-push-shinyapp.yml
@@ -24,14 +24,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Build
         uses: docker/build-push-action@v5
         with:
@@ -39,9 +31,9 @@ jobs:
           file: ${{ env.DOCKERFILE }}
           load: true
           tags: ${{ env.CONTAINER_NAME }}:testing
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       # - name: Test
       #   run: |
       #     expected=\

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ Test docker is installed by running:
 ```
 docker run hello-world
 ```
+At this point, you can also download the docker images needed for deployment:
+```
+docker pull  ghcr.io/uomresearchit/pb-rclient:latest
+docker pull ghcr.io/uomresearchit/pb-shinyapp:latest
+docker pull docker.io/bitnami/rabbitmq:3.12
+docker pull quay.io/minio/minio:latest
+docker pull jc21/nginx-proxy-manager:latest
+```
 
 ### One time setup
 Navigate to the cloned repo directory, and setup minio for the first time:
@@ -98,3 +106,36 @@ Websockets Support: On
 Traffic should now be forwarded to the right frontentd for each domain.
 
 ### SSL certificates
+
+### Debugging
+
+#### Logs
+An important access point for debugging the site is the docker compose logs.
+
+You can access all of the logs together with:
+```
+docker compose logs -f
+```
+where the -f option follows the logs live.
+
+Alternatively, you can look at the logs of each service (or a selected group) with
+```
+docker compose logs -f <service name>
+```
+The services are as follows:
+
+- **shinyapp**: The shiny app, serving the public site.
+- **minio**: The minio service, serving the front end for the database.
+- **rclient**: An mqtt client, listening for events in the minio site, in charge of the data pre-processing workflow.
+- **rabbitmq**: The message broker used to connect the minio and rclient services.
+- **proxy**: The nginx proxy manager, in charge of the domain routing.
+
+#### Docker exec
+
+Another useful tool for debugging is the docker exec command, which allows you to jump inside of one of the running containers.
+
+For example, to jump inside the shinyapp container, you can run:
+```
+docker exec -it pb-shinyapp bash
+```
+This will open a bash shell inside the container, where you can run commands to debug the app.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     command: tunnel --no-autoupdate run
 
   proxy:
-    image: 'jc21/nginx-proxy-manager:latest'
+    image: jc21/nginx-proxy-manager:latest
     container_name: pB-proxy
     depends_on:
       - cloudflared
@@ -26,7 +26,7 @@ services:
       timeout: 3s
 
   minio:
-    image: quay.io/minio/minio
+    image: quay.io/minio/minio:latest
     container_name: pB-minio
     restart: unless-stopped
     ports:
@@ -61,9 +61,10 @@ services:
       retries: 5
 
   rclient:
-    build:
-      context: ./db
-      dockerfile: Dockerfile.rclient
+    image: ghcr.io/uomresearchit/pb-rclient:latest
+    # build:
+    #   context: ./db
+    #   dockerfile: Dockerfile.rclient
     container_name: pB-rclient
     restart: unless-stopped
     volumes:
@@ -75,9 +76,10 @@ services:
       - rabbitmq
 
   shinyapp:
-    build:
-      context: ./app
-      dockerfile: Dockerfile.shinyapp
+    image: ghcr.io/uomresearchit/pb-shinyapp:latest
+    # build:
+    #   context: ./app
+    #   dockerfile: Dockerfile.shinyapp
     container_name: pB-shinyapp
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Compose uses images for rclient and shinyapp instead of building them.
Adds docker pull commands and debugging info to README.
Uses buildx cache to speed up gh action.