### PR TITLE
Vector graphics downloads

### DIFF
--- a/app/R/app_server.R
+++ b/app/R/app_server.R
@@ -15,7 +15,11 @@ source("R/plot_functions.R")
 source("R/save_as_button.R")
 
 app_server <- function(input, output, session) {
-  thematic::thematic_shiny()
+  thematic::thematic_shiny(
+    bg = "#FFFFFF",
+    fg = "#000000",
+    accent = "#660099"
+  )
 
   # Muffle known grid/font encoding warnings for unicode arrow markers.
   muffle_arrow_warning <- function(expr) {

--- a/app/R/app_ui.R
+++ b/app/R/app_ui.R
@@ -143,11 +143,11 @@ app_ui <- function(request) {
                 div(class = "container", style = "column-gap: 10px;",
                   div(
                     plotOutput("heatmap",
-                      width = 250,
+                      width = 300,
                       height = 500,
                       brush = "heatmap_brush"
                     ),
-                    save_as_ui("heatmap_save_as", 250, 500),
+                    save_as_ui("heatmap_save_as", 300, 500),
                   ),
                   div(
                     uiOutput("sub_heat"),

--- a/app/R/plot_functions.R
+++ b/app/R/plot_functions.R
@@ -250,7 +250,8 @@ bar_plot <- function(gene_dropdown, df) {
     scale_y_continuous(name = "Normalized Log2-protein intensity") +
     theme_light() +
     theme(text = element_text(family = font_family_web, size = title_fontsize),
-          axis.text.x = element_text(size = label_fontsize, angle = 45),
+          axis.text.x = element_text(size = label_fontsize,
+                 angle = 45, hjust = 1, vjust = 1),
           axis.text.y = element_text(size = label_fontsize),
           legend.position = "none") +
     scale_fill_manual(values = hcl.colors(length(unique(df_plot$experiment_type)))) +
@@ -275,7 +276,8 @@ box_plot <- function(gene_dropdown, df) {
     scale_y_continuous(name = "Normalized Log2-protein intensity") +
     theme_light() +
     theme(text = element_text(family = font_family_web, size = title_fontsize),
-          axis.text.x = element_text(size = label_fontsize, angle = 45),
+          axis.text.x = element_text(size = label_fontsize,
+                 angle = 45, hjust = 1, vjust = 1),
           axis.text.y = element_text(size = label_fontsize),
           legend.position = "none") +
     scale_fill_manual(values = hcl.colors(length(unique(df_plot$experiment_type))))

--- a/app/R/save_as_button.R
+++ b/app/R/save_as_button.R
@@ -47,30 +47,39 @@ save_as_ui <- function(id,
       id = NS(id, "save_as_options"),
       style = "display: none;",
       div(
+        style = "display: flex;
+          flex-direction: column;
+          align-items: center;",
+        div(
+          radioButtons(
+            NS(id, "download_format"),
+            label = NULL,
+            choices = list("png",
+                          "svg"),
+            selected = "png",
+            inline = TRUE
+          )
+        ),
+        div(
+          id = NS(id, "resolution_container"),
+          style = "display: flex;
+          flex-direction: row;
+          height: 30px;",
+          numericInput(
+            NS(id, "download_image_resolution"),
+            label = NULL,
+            value = default_dpi,
+            width = "80px",
+          ),
+          span("dpi", style = "margin-left: 5px; margin-top: 5px;")
+        )
+      ),
+      div(
         downloadButton(
           NS(id, "download_button"),
           "Save image",
           class = "btn-info",
-          style = "padding: 20px 10px;"
-        )
-      ),
-      div(
-        radioButtons(
-          NS(id, "download_format"),
-          label = "Format:",
-          choices = list("png",
-                         "svg"),
-          selected = "png",
-          inline = TRUE
-        )
-      ),
-      div(
-        id = NS(id, "resolution_container"),
-        numericInput(
-          NS(id, "download_image_resolution"),
-          label = "Resolution [dpi]",
-          value = default_dpi,
-          width = "120px"
+          style = "padding: 25px 10px;"
         )
       ),
       div(
@@ -116,10 +125,10 @@ save_as_server <- function(id,
     observe({
       req(input$download_format)
       if (identical(input$download_format, "png")) {
-        sel = paste("#", id, "-download_image_resolution", sep = "")
+        sel = paste("#", id, "-resolution_container", sep = "")
         shinyjs::show(selector = sel)
       } else {
-        sel = paste("#", id, "-download_image_resolution", sep = "")
+        sel = paste("#", id, "-resolution_container", sep = "")
         shinyjs::hide(selector = sel)
       }
     })

--- a/app/R/save_as_button.R
+++ b/app/R/save_as_button.R
@@ -65,6 +65,7 @@ save_as_ui <- function(id,
         )
       ),
       div(
+        id = NS(id, "resolution_container"),
         numericInput(
           NS(id, "download_image_resolution"),
           label = "Resolution [dpi]",
@@ -110,6 +111,17 @@ save_as_server <- function(id,
       shinyjs::hide(selector = sel)
       # Scroll to the bottom of the page
       shinyjs::runjs("window.scrollTo(0,document.body.scrollHeight);")
+    })
+    # Show resolution control for PNG only.
+    observe({
+      req(input$download_format)
+      if (identical(input$download_format, "png")) {
+        sel = paste("#", id, "-download_image_resolution", sep = "")
+        shinyjs::show(selector = sel)
+      } else {
+        sel = paste("#", id, "-download_image_resolution", sep = "")
+        shinyjs::hide(selector = sel)
+      }
     })
     output$download_button <- downloadHandler(
       filename = function() {

--- a/app/R/save_as_button.R
+++ b/app/R/save_as_button.R
@@ -51,13 +51,14 @@ save_as_ui <- function(id,
           flex-direction: column;
           align-items: center;",
         div(
-          radioButtons(
+          style = "
+          height: 38px;",
+          selectInput(
             NS(id, "download_format"),
             label = NULL,
-            choices = list("png",
-                          "svg"),
+            choices = c("png", "svg", "pdf"),
             selected = "png",
-            inline = TRUE
+            width = "110px"
           )
         ),
         div(
@@ -151,31 +152,31 @@ save_as_server <- function(id,
         w_in <- input$download_image_width / screen_dpi
         h_in <- input$download_image_height / screen_dpi
         format <- input$download_format
-        if (format == "png") {
-          png(file, width = w_px, height = h_px, units = "px", res = dpi)
-        } else if (format == "svg") {
-          svg(file, width = w_in, height = h_in)
-        }
         if (class(plot)[1] %in% c("Heatmap", "HeatmapList", "ComplexHeatmap")) {
           # Complex heatmaps (from ComplexHeatmap package)
           if (format == "png") {
+            png(file, width = w_px, height = h_px, units = "px", res = dpi)
             print(plot)
             dev.off()
           } else if (format == "svg") {
             svg(file, width = w_in, height = h_in)
             print(plot)
             dev.off()
+          } else if (format == "pdf") {
+            pdf(file, width = w_in, height = h_in)
+            print(plot)
+            dev.off()
           }
           return()
         } else {
+          # ggplot objects
           if (format == "png") {
-              ggsave(
+            ggsave(
               filename = file,
               plot = plot,
               dpi = dpi,
               device = format
             )
-            dev.off()
           } else if (format == "svg") {
             ggsave(
               filename = file,
@@ -184,6 +185,20 @@ save_as_server <- function(id,
               height = h_in,
               units = "in",
               device = "svg"
+            )
+          } else if (format == "pdf") {
+            plot_pdf <- if (inherits(plot, "ggplot")) {
+              plot + theme(text = element_text(family = "sans"))
+            } else {
+              plot
+            }
+            ggsave(
+              filename = file,
+              plot = plot_pdf,
+              width = w_in,
+              height = h_in,
+              units = "in",
+              device = "pdf"
             )
           }
         }

--- a/app/R/save_as_button.R
+++ b/app/R/save_as_button.R
@@ -55,12 +55,10 @@ save_as_ui <- function(id,
         )
       ),
       div(
-        style = "display: none;",
         radioButtons(
           NS(id, "download_format"),
           label = "Format:",
           choices = list("png",
-                         "pdf",
                          "svg"),
           selected = "png",
           inline = TRUE
@@ -127,33 +125,47 @@ save_as_server <- function(id,
       content = function(file) {
         screen_dpi <- 72
         dpi <- input$download_image_resolution
-        w <- input$download_image_width
-        h <- input$download_image_height
-        w <- as.integer(dpi * w / screen_dpi)
-        h <- as.integer(dpi * h / screen_dpi)
+        w_px <- as.integer(dpi * input$download_image_width / screen_dpi)
+        h_px <- as.integer(dpi * input$download_image_height / screen_dpi)
+        w_in <- input$download_image_width / screen_dpi
+        h_in <- input$download_image_height / screen_dpi
         format <- input$download_format
         if (format == "png") {
-          png(file, width = w, height = h, units = "px", res = dpi)
-        } else if (format == "pdf") {
-          pdf(file, width = w, height = h)
+          png(file, width = w_px, height = h_px, units = "px", res = dpi)
         } else if (format == "svg") {
-          svg(file, width = w, height = h)
+          svg(file, width = w_in, height = h_in)
         }
         if (class(plot)[1] %in% c("Heatmap", "HeatmapList", "ComplexHeatmap")) {
-          print(plot)
-          dev.off()
+          # Complex heatmaps (from ComplexHeatmap package)
+          if (format == "png") {
+            print(plot)
+            dev.off()
+          } else if (format == "svg") {
+            svg(file, width = w_in, height = h_in)
+            print(plot)
+            dev.off()
+          }
           return()
+        } else {
+          if (format == "png") {
+              ggsave(
+              filename = file,
+              plot = plot,
+              dpi = dpi,
+              device = format
+            )
+            dev.off()
+          } else if (format == "svg") {
+            ggsave(
+              filename = file,
+              plot = plot,
+              width = w_in,
+              height = h_in,
+              units = "in",
+              device = "svg"
+            )
+          }
         }
-        ggsave(
-          filename = file,
-          plot = plot,
-          dpi = dpi,
-          # units = "px",
-          # width = w,
-          # height = h,
-          device = format
-        )
-        dev.off()
       }
     )
   })

--- a/app/R/save_as_button.R
+++ b/app/R/save_as_button.R
@@ -163,7 +163,11 @@ save_as_server <- function(id,
             print(plot)
             dev.off()
           } else if (format == "pdf") {
-            pdf(file, width = w_in, height = h_in)
+            if (capabilities("cairo")) {
+              grDevices::cairo_pdf(file, width = w_in, height = h_in)
+            } else {
+              pdf(file, width = w_in, height = h_in)
+            }
             print(plot)
             dev.off()
           }


### PR DESCRIPTION
- Enables svg and pdf downloads.
- Hides resolution input for non-png downloads
- Fixes overlapping labels at an angle

Resolves #84 
